### PR TITLE
Removed references to '%context%'  (dead code)

### DIFF
--- a/lib/internal/Magento/Framework/RequireJs/Config.php
+++ b/lib/internal/Magento/Framework/RequireJs/Config.php
@@ -155,22 +155,15 @@ config;
     {
         $distributedConfig = '';
         $customConfigFiles = $this->fileSource->getFiles($this->design->getDesignTheme(), self::CONFIG_FILE_NAME);
+        
         foreach ($customConfigFiles as $file) {
             /** @var $fileReader \Magento\Framework\Filesystem\File\Read */
             $fileReader = $this->readFactory->create($file->getFilename(), DriverPool::FILE);
             $config = $fileReader->readAll($file->getName());
-            $distributedConfig .= str_replace(
-                ['%config%', '%context%'],
-                [$config, $file->getModule()],
-                self::PARTIAL_CONFIG_TEMPLATE
-            );
+            $distributedConfig .= str_replace('%config%', $config, self::PARTIAL_CONFIG_TEMPLATE);
         }
 
-        $fullConfig = str_replace(
-            ['%function%', '%usages%'],
-            [$distributedConfig],
-            self::FULL_CONFIG_TEMPLATE
-        );
+        $fullConfig = str_replace(['%function%', '%usages%'], [$distributedConfig], self::FULL_CONFIG_TEMPLATE);
 
         if ($this->minification->isEnabled('js')) {
             $fullConfig = $this->minifyAdapter->minify($fullConfig);


### PR DESCRIPTION
# Description (*)
`Magento\Framework\RequireJs\Config` has a call to `str_replace` for `%context%` reference, which doesn't exist.

### Related Pull Requests
N/A

### Fixed Issues (if relevant)
N/A

### Manual testing scenarios (*)
All references to create RequireJS config from config variables should contain same output as before update, since there are no references to `%context%` in backen logic.

### Questions or comments
Dead code elimination

### Contribution checklist (*)
 - [ x ] Pull request has a meaningful description of its purpose
 - [ x ] All commits are accompanied by meaningful commit messages
 - [ x ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ x ] All automated tests passed successfully (all builds are green)
